### PR TITLE
Use @std/url and change to "master"

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -15,7 +15,7 @@
     "@std/fmt": "jsr:@std/fmt@0.225.4",
     "@std/http": "jsr:@std/http@0.224.4",
     "@std/http/user-agent": "jsr:@std/http@~0.223/user-agent",
-    "@std/path": "jsr:@std/path@0.225.2"
+    "@std/url": "jsr:@std/url@0.224.1"
   },
   "deploy": {
     "project": "reproxy",

--- a/deno.lock
+++ b/deno.lock
@@ -9,7 +9,6 @@
       "jsr:@std/assert@0.226.0": "jsr:@std/assert@0.226.0",
       "jsr:@std/assert@^0.223.0": "jsr:@std/assert@0.223.0",
       "jsr:@std/assert@^0.224.0": "jsr:@std/assert@0.224.0",
-      "jsr:@std/assert@^0.226.0": "jsr:@std/assert@0.226.0",
       "jsr:@std/bytes@0.223": "jsr:@std/bytes@0.223.0",
       "jsr:@std/bytes@0.224": "jsr:@std/bytes@0.224.0",
       "jsr:@std/bytes@^0.223.0": "jsr:@std/bytes@0.223.0",
@@ -27,7 +26,9 @@
       "jsr:@std/media-types@0.223": "jsr:@std/media-types@0.223.0",
       "jsr:@std/media-types@0.224": "jsr:@std/media-types@0.224.1",
       "jsr:@std/path@0.223": "jsr:@std/path@0.223.0",
-      "jsr:@std/path@0.225.2": "jsr:@std/path@0.225.2",
+      "jsr:@std/path@1.0.0-rc.1": "jsr:@std/path@1.0.0-rc.1",
+      "jsr:@std/url@0.224.1": "jsr:@std/url@0.224.1",
+      "npm:@types/node": "npm:@types/node@18.16.19",
       "npm:path-to-regexp@6.2.1": "npm:path-to-regexp@6.2.1"
     },
     "jsr": {
@@ -125,14 +126,21 @@
       "@std/path@0.223.0": {
         "integrity": "593963402d7e6597f5a6e620931661053572c982fc014000459edc1f93cc3989"
       },
-      "@std/path@0.225.2": {
-        "integrity": "0f2db41d36b50ef048dcb0399aac720a5348638dd3cb5bf80685bf2a745aa506",
+      "@std/path@1.0.0-rc.1": {
+        "integrity": "b8c00ae2f19106a6bb7cbf1ab9be52aa70de1605daeb2dbdc4f87a7cbaf10ff6"
+      },
+      "@std/url@0.224.1": {
+        "integrity": "19f0e1c6ff8fc2ef9522a746595c24f53be47425daa910eb8ef39cbb5e00b3df",
         "dependencies": [
-          "jsr:@std/assert@^0.226.0"
+          "jsr:@std/path@1.0.0-rc.1"
         ]
       }
     },
     "npm": {
+      "@types/node@18.16.19": {
+        "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
+        "dependencies": {}
+      },
       "path-to-regexp@6.2.1": {
         "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
         "dependencies": {}
@@ -164,7 +172,7 @@
       "jsr:@std/fmt@0.225.4",
       "jsr:@std/http@0.224.4",
       "jsr:@std/http@~0.223",
-      "jsr:@std/path@0.225.2"
+      "jsr:@std/url@0.224.1"
     ]
   }
 }

--- a/src/libs/redirect.ts
+++ b/src/libs/redirect.ts
@@ -7,7 +7,7 @@ import { getRepository } from "./env.ts";
 export function redirect<R extends string>(
   ctx: RouterContext<R>,
   userAgent: UserAgent,
-  ref: string = "HEAD"
+  ref: string = "master"
 ): void {
   const repository = getRepository();
   const url = join(

--- a/src/libs/redirect.ts
+++ b/src/libs/redirect.ts
@@ -1,7 +1,7 @@
 import type { RouterContext } from "@oak/oak";
 import { STATUS_CODE } from "@std/http/status";
 import { UserAgent } from "@std/http/user-agent";
-import { join } from "@std/path";
+import { join } from "@std/url";
 import { getRepository } from "./env.ts";
 
 export function redirect<R extends string>(
@@ -10,16 +10,14 @@ export function redirect<R extends string>(
   ref: string = "HEAD"
 ): void {
   const repository = getRepository();
-  const url: string =
-    "https://" +
-    join(
-      "github.com",
-      repository.owner,
-      repository.name,
-      "blob",
-      ref,
-      repository.path
-    );
+  const url = join(
+    new URL("https://github.com"),
+    repository.owner,
+    repository.name,
+    "blob",
+    ref,
+    repository.path
+  );
 
   if (userAgent?.browser.name) {
     ctx.response.status = STATUS_CODE.PermanentRedirect;

--- a/test/libs/redirect_test.ts
+++ b/test/libs/redirect_test.ts
@@ -13,7 +13,7 @@ Deno.test("Redirect Detection", <R extends string>() => {
   assertEquals(ctx.response.status, STATUS_CODE.PermanentRedirect);
   assertEquals(
     ctx.response.headers.get("location"),
-    `https://github.com/${testRepo.owner}/${testRepo.name}/blob/HEAD/${testRepo.path}`
+    `https://github.com/${testRepo.owner}/${testRepo.name}/blob/master/${testRepo.path}`
   );
 });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### ✔︎ Checklists

- [ ] This Pull Request introduces a new feature.
- [ ] This Pull Request fixes a bug.

<br />

### 🔄 Type of the Change

- [ ] 🎉 Feature
- [ ] 🧰 Bug
- [ ] 🛡️ Security
- [ ] 📖 Documentation
- [x] 🧹 Refactoring
- [ ] 🧪 Testing
- [ ] 🔧 Maintenance
- [ ] 🎽 CI
- [ ] ⛓️ Dependencies
- [ ] 🧠 Meta

<br />

### ✏️ Description

- Because of the processing URL, not the directory path.
- Redirects to the default branch, not head hash.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct](https://github.com/5ouma/reproxy/blob/main/.github/CODE_OF_CONDUCT.md).
