### PR TITLE
JS doesn't export globally with module import

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ To do this, simply add the ref name to the sub-directory.
      1. Add this code to the `index.ts`
 
         ```ts
-        import "@5ouma/reproxy";
+        import { app } from "@5ouma/reproxy";
+        export default app;
         ```
 
      2. Run these commands
@@ -97,7 +98,8 @@ To do this, simply add the ref name to the sub-directory.
 2. Add this code to the `index.ts`
 
    ```ts
-   import "@5ouma/reproxy";
+   import { app } from "@5ouma/reproxy";
+   export default app;
    ```
 
 3. Deploy with these commands

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "@std/assert";
 import { STATUS_CODE } from "@std/http/status";
 
-import app from "./server.ts";
+import { app } from "./server.ts";
 import {
   exportRepo,
   testRef,

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,8 +21,7 @@ import { checkRedirect, getContent, type Repository } from "./libs/mod.ts";
  * });
  * ```
  */
-const app: Hono = new Hono();
-export default app;
+export const app: Hono = new Hono();
 app.use(logger());
 app
   .get("/:ref?", async (ctx: Context) => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### 🔄 Type of the Change

- [ ] 🎉 New Feature
- [x] 🧰 Bug
- [ ] 🛡️ Security
- [ ] 📖 Documentation
- [ ] 🏎️ Performance
- [ ] 🧹 Refactoring
- [ ] 🧪 Testing
- [ ] 🔧 Maintenance
- [ ] 🎽 CI
- [ ] ⛓️ Dependencies
- [ ] 🧠 Meta

<br />

### ✏️ Description

It needs to be re-exported in the caller script.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct](https://github.com/5ouma/reproxy/blob/main/.github/CODE_OF_CONDUCT.md).
