### PR TITLE
Use default export for Bun and Workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ To do this, simply add the ref name to the sub-directory.
      1. Add this code to the `index.ts`
 
         ```ts
-        import { app } from "@5ouma/reproxy";
-        export default app;
+        export { default } from "@5ouma/reproxy";
         ```
 
      2. Run these commands
@@ -98,8 +97,7 @@ To do this, simply add the ref name to the sub-directory.
 2. Add this code to the `index.ts`
 
    ```ts
-   import { app } from "@5ouma/reproxy";
-   export default app;
+   export { default } from "@5ouma/reproxy";
    ```
 
 3. Deploy with these commands

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "@std/assert";
 import { STATUS_CODE } from "@std/http/status";
 
-import { app } from "./server.ts";
+import app from "./server.ts";
 import {
   exportRepo,
   testRef,

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,7 +21,8 @@ import { checkRedirect, getContent, type Repository } from "./libs/mod.ts";
  * });
  * ```
  */
-export const app: Hono = new Hono();
+const app: Hono = new Hono();
+export default app;
 app.use(logger());
 app
   .get("/:ref?", async (ctx: Context) => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### 🔄 Type of the Change

- [ ] 🎉 New Feature
- [ ] 🧰 Bug
- [ ] 🛡️ Security
- [ ] 📖 Documentation
- [ ] 🏎️ Performance
- [x] 🧹 Refactoring
- [ ] 🧪 Testing
- [ ] 🔧 Maintenance
- [ ] 🎽 CI
- [ ] ⛓️ Dependencies
- [ ] 🧠 Meta

<br />

### ✏️ Description

JS can export as default from a module with one line.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct](https://github.com/5ouma/reproxy/blob/main/.github/CODE_OF_CONDUCT.md).
