### PR TITLE
Run `deno serve` instead of the `deno run`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,9 +8,9 @@
   },
   "fmt": { "exclude": ["LICENSE", "README.md", ".github/**/*.md"] },
   "tasks": {
-    "run": "deno run --env-file='.env' -EN='api.github.com'",
-    "start": "deno task run src/server.ts",
-    "dev": "deno task run --watch src/server.ts",
+    "serve": "deno serve --env-file='.env' -EN='api.github.com'",
+    "start": "deno task serve src/server.ts",
+    "dev": "deno task serve --watch src/server.ts",
     "test": "deno test --doc -EN='api.github.com' --parallel --shuffle",
     "cov": "deno task test --coverage && deno coverage --lcov > coverage.lcov"
   },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### 🔄 Type of the Change

- [ ] 🎉 New Feature
- [x] 🧰 Bug
- [ ] 🛡️ Security
- [ ] 📖 Documentation
- [ ] 🏎️ Performance
- [ ] 🧹 Refactoring
- [ ] 🧪 Testing
- [ ] 🔧 Maintenance
- [ ] 🎽 CI
- [ ] ⛓️ Dependencies
- [ ] 🧠 Meta

<br />

### ✏️ Description

Since `deno run` doesn't treat the default exports.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct](https://github.com/5ouma/reproxy/blob/main/.github/CODE_OF_CONDUCT.md).
