### PR TITLE
Allow slashes for the ref parameter

### DIFF
--- a/src/libs/test_utils.ts
+++ b/src/libs/test_utils.ts
@@ -41,6 +41,16 @@ export const unknownRepo: Repository = {
 export const testRef = "v1.0.0";
 
 /**
+ * Sample version reference with slash for test.
+ *
+ * @example
+ * ```ts
+ * const ref = testRefSlash;
+ * ```
+ */
+export const testRefSlash = "renovate/configure";
+
+/**
  * Sample user agent for test.
  *
  * @example

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -5,6 +5,7 @@ import app from "./server.ts";
 import {
   exportRepo,
   testRef,
+  testRefSlash,
   testRepo,
   testUserAgent,
 } from "./libs/test_utils.ts";
@@ -51,11 +52,23 @@ Deno.test("Serve", async (t: Deno.TestContext) => {
     assertEquals(res.status, STATUS_CODE.PermanentRedirect);
   });
 
-  await t.step("*", async () => {
+  await t.step("/:ref (with Slash)", async () => {
     exportRepo(testRepo);
-    const res: Response = await app.request("/anything/else");
+    const res: Response = await app.request(`/${testRefSlash}`);
 
-    assertEquals(res.headers.get("Location"), "/");
-    assertEquals(res.status, STATUS_CODE.SeeOther);
+    assertEquals(res.status, STATUS_CODE.OK);
+  });
+
+  await t.step("/:ref (withSlash, Redirect)", async () => {
+    exportRepo(testRepo);
+    const res: Response = await app.request(`/${testRefSlash}`, {
+      headers: { "User-Agent": testUserAgent.toString() },
+    });
+
+    assertEquals(
+      res.headers.get("Location"),
+      getGitHubUrl(testRepo, testRefSlash).toString(),
+    );
+    assertEquals(res.status, STATUS_CODE.PermanentRedirect);
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,7 +27,7 @@ const app: Hono = new Hono();
 export default app;
 app.use(logger());
 app
-  .get("/:ref?", async (ctx: Context) => {
+  .get("/:ref{.+}?", async (ctx: Context) => {
     const { REPOSITORY_OWNER, REPOSITORY_NAME, REPOSITORY_PATH, GITHUB_TOKEN } =
       env<
         {
@@ -53,5 +53,4 @@ app
     return url
       ? ctx.redirect(url.toString(), STATUS_CODE.PermanentRedirect)
       : ctx.text(...await getContent(repository, ref, GITHUB_TOKEN));
-  })
-  .get("*", (ctx: Context) => ctx.redirect("/", STATUS_CODE.SeeOther));
+  });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### ✏️ Description

Branch names with slashes will become able to be used.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

### 🔄 Type of the Change

- [x] 🎉 New Feature
- [ ] 🧰 Bug
- [ ] 🛡️ Security
- [ ] 📖 Documentation
- [ ] 🏎️ Performance
- [ ] 🧹 Refactoring
- [ ] 🧪 Testing
- [ ] 🔧 Maintenance
- [ ] 🎽 CI
- [ ] 🧠 Meta

<br />

- [x] I agree to follow the
      [Code of Conduct](https://github.com/5ouma/reproxy/blob/main/.github/CODE_OF_CONDUCT.md).
