### PR TITLE
Remove permissions from GitHub Actions token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
       - deno.lock
       - .github/workflows/ci.yml
 
+permissions: {}
+
 jobs:
   lint-check:
     name: 🧹 Lint Check

--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -5,12 +5,13 @@ on:
     - cron: 0 0 * * *
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   Update:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: Ubuntu-Latest
 
     steps:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   pre-commit:
     runs-on: Ubuntu-Latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
       - main
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   tagpr:
     name: 🏷️ Release a New Version


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### ✏️ Description

It's not needed to pass any permissions by default.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

### 🔄 Type of the Change

- [ ] 🎉 New Feature
- [ ] 🧰 Bug
- [ ] 🛡️ Security
- [ ] 📖 Documentation
- [ ] 🏎️ Performance
- [ ] 🧹 Refactoring
- [ ] 🧪 Testing
- [ ] 🔧 Maintenance
- [x] 🎽 CI
- [ ] 🧠 Meta

<br />

- [x] I agree to follow the
      [Code of Conduct](https://github.com/5ouma/reproxy/blob/main/.github/CODE_OF_CONDUCT.md).
