### PR TITLE
Remove the coverage command from the task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         uses: 5ouma/utils/setup-deno-with-cache@3d7fe8d0af9597d68e95f581c032b77813c024af # v0.1.1
 
       - name: 🧪 Run Tests
-        run: deno task test:ci
+        run: deno task test:cov
 
       - name: ☂️ Upload Coverage
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .env
-coverage.lcov
 coverage/
 junit.xml

--- a/deno.json
+++ b/deno.json
@@ -12,7 +12,7 @@
     "start": "deno task serve src/server.ts",
     "dev": "deno task serve --watch src/server.ts",
     "test": "deno test --doc -EN='api.github.com' --parallel --shuffle",
-    "test:ci": "deno task test --coverage --junit-path='junit.xml' && deno coverage --lcov > coverage.lcov"
+    "test:cov": "deno task test --coverage --junit-path='junit.xml'"
   },
   "imports": {
     "@hono/hono": "jsr:@hono/hono@4.7.7",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### ✏️ Description

Coverage generation is now automatically done.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct].

[Code of Conduct]: https://github.com/5ouma/reproxy/blob/main/.github/CODE_OF_CONDUCT.md
