### PR TITLE
Keep PR is not possible to merge until success

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -1,0 +1,21 @@
+name: 🛡️ Merge Gatekeeper
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  merge-gatekeeper:
+    permissions:
+      checks: read
+      statuses: read
+    runs-on: Ubuntu-Latest
+    timeout-minutes: 10
+
+    steps:
+      - name: 🛡️ Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@09af7a82c1666d0e64d2bd8c01797a0bcfd3bb5d # v1.2.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ignored: CodeRabbit


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### ✏️ Description

It observes other workflows' status and prevents unwilling merges.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct].

[Code of Conduct]: https://github.com/5ouma/reproxy/blob/main/.github/CODE_OF_CONDUCT.md
