### PR TITLE
Remove GitHub token permissions from the CI checker

### DIFF
--- a/.github/workflows/ci-checker.yml
+++ b/.github/workflows/ci-checker.yml
@@ -24,9 +24,6 @@ jobs:
 
   merge-pr:
     name: 🔀 Merge PR
-    permissions:
-      contents: write
-      pull-requests: write
     needs: merge-gatekeeper
     if: ${{ github.event.pull_request.user.login == 'renovate[bot]' && github.event.sender.login == 'autofix-ci[bot]' && toJson(github.event.pull_request.requested_reviewers) == '[]' }}
     runs-on: Ubuntu-Latest


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### ✏️ Description

They're not needed because of using the App Token.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct].

[Code of Conduct]: https://github.com/5ouma/reproxy/blob/main/.github/CODE_OF_CONDUCT.md
