### PR TITLE
Set release persist-credential false

### DIFF
--- a/.github/ghalint.yml
+++ b/.github/ghalint.yml
@@ -1,4 +1,0 @@
-excludes:
-  - policy_name: checkout_persist_credentials_should_be_false
-    workflow_file_path: .github/workflows/release.yml
-    job_name: tagpr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,12 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: true
+          persist-credentials: false
+
+      - name: 🔐 Set up Credential Helper
+        run: gh auth setup-git
+        env:
+          GH_HOST: github.com
 
       - name: 🔖 Release a new version
         id: tagpr
@@ -41,6 +46,7 @@ jobs:
         with:
           config: .github/tagpr.ini
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   publish:


### PR DESCRIPTION
### ⚠️ Issue <!-- rumdl-disable-line MD041 -->

close #

<br />

### ✏️ Description

Set the GitHub CLI as a Git credential helper to operate.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct].

[Code of Conduct]: https://github.com/5ouma/reproxy/blob/main/.github/CODE_OF_CONDUCT.md
