### PR TITLE
Loosen timeout minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   lint-check:
     name: 🧹 Lint Check
     runs-on: Ubuntu-Slim
-    timeout-minutes: 1
+    timeout-minutes: 2
 
     steps:
       - name: 🚚 Check out repository
@@ -52,7 +52,7 @@ jobs:
   format-check:
     name: 📝 Format Check
     runs-on: Ubuntu-Slim
-    timeout-minutes: 1
+    timeout-minutes: 2
 
     steps:
       - name: 🚚 Check out repository
@@ -71,7 +71,7 @@ jobs:
   type-check:
     name: 🔍 Type Check
     runs-on: Ubuntu-Slim
-    timeout-minutes: 1
+    timeout-minutes: 2
 
     steps:
       - name: 🚚 Check out repository
@@ -99,7 +99,7 @@ jobs:
     environment:
       name: CI
       deployment: false
-    timeout-minutes: 1
+    timeout-minutes: 2
 
     steps:
       - name: 🚚 Check out repository
@@ -136,7 +136,7 @@ jobs:
   dry-run-publish:
     name: 📦 Dry Run Publish
     runs-on: Ubuntu-Slim
-    timeout-minutes: 1
+    timeout-minutes: 2
 
     steps:
       - name: 🚚 Check out repository


### PR DESCRIPTION
### ⚠️ Issue <!-- rumdl-disable-line MD041 -->

close #

<br />

### ✏️ Description

One minute is too tight to finish workflows completely.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct].

[Code of Conduct]: https://github.com/5ouma/reproxy/blob/main/.github/CODE_OF_CONDUCT.md
